### PR TITLE
refactor(multikueue): Remove global state from adapter creation

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -353,12 +353,13 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.C
 		}
 
 		if features.Enabled(features.MultiKueueAdaptersForCustomJobs) && cfg.MultiKueue != nil && len(cfg.MultiKueue.ExternalFrameworks) > 0 {
-			if err := externalframeworks.Initialize(cfg.MultiKueue.ExternalFrameworks); err != nil {
-				return fmt.Errorf("could not initialize external frameworks: %w", err)
+			externalAdapters, err := externalframeworks.NewAdapters(cfg.MultiKueue.ExternalFrameworks)
+			if err != nil {
+				return fmt.Errorf("could not create external framework adapters: %w", err)
 			}
 
 			// Add external framework adapters to the adapters map
-			for _, adapter := range externalframeworks.GetAllAdapters() {
+			for _, adapter := range externalAdapters {
 				gvk := adapter.GVK().String()
 				setupLog.Info("Creating external framework MultiKueue adapter", "gvk", gvk)
 				adapters[gvk] = adapter

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -116,40 +116,36 @@ func validateMultiKueue(c *configapi.Configuration) field.ErrorList {
 
 		if len(c.MultiKueue.ExternalFrameworks) > 0 {
 			path := multiKueuePath.Child("externalFrameworks")
-			if !features.Enabled(features.MultiKueueAdaptersForCustomJobs) {
-				allErrs = append(allErrs, field.Forbidden(path, "can be set only when MultiKueueAdaptersForCustomJobs feature gate is enabled"))
-			} else {
-				enabledIntegrations := sets.New[string]()
-				if c.Integrations != nil {
-					enabledIntegrations = sets.New(c.Integrations.Frameworks...)
-				}
+			enabledIntegrations := sets.New[string]()
+			if c.Integrations != nil {
+				enabledIntegrations = sets.New(c.Integrations.Frameworks...)
+			}
 
-				builtInAdapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
-				if err != nil {
-					allErrs = append(allErrs, field.InternalError(path, err))
-				}
-				builtInGVKs := sets.New[string]()
-				for gvk := range builtInAdapters {
-					builtInGVKs.Insert(gvk)
-				}
+			builtInAdapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
+			if err != nil {
+				allErrs = append(allErrs, field.InternalError(path, err))
+			}
+			builtInGVKs := sets.New[string]()
+			for gvk := range builtInAdapters {
+				builtInGVKs.Insert(gvk)
+			}
 
-				seenGVKs := sets.New[string]()
-				for i, f := range c.MultiKueue.ExternalFrameworks {
-					fldPath := path.Index(i).Child("name")
-					parsedGVK, _ := schema.ParseKindArg(f.Name)
-					if parsedGVK == nil {
-						allErrs = append(allErrs, field.Invalid(fldPath, f.Name, "must be in 'kind.version.group' format"))
-						continue
-					}
-					gvk := parsedGVK.String()
-					if seenGVKs.Has(gvk) {
-						allErrs = append(allErrs, field.Duplicate(fldPath, f.Name))
-					} else {
-						seenGVKs.Insert(gvk)
-					}
-					if builtInGVKs.Has(gvk) {
-						allErrs = append(allErrs, field.Invalid(fldPath, f.Name, "conflicts with a built-in MultiKueue adapter"))
-					}
+			seenGVKs := sets.New[string]()
+			for i, f := range c.MultiKueue.ExternalFrameworks {
+				fldPath := path.Index(i).Child("name")
+				parsedGVK, _ := schema.ParseKindArg(f.Name)
+				if parsedGVK == nil {
+					allErrs = append(allErrs, field.Invalid(fldPath, f.Name, "must be in 'kind.version.group' format"))
+					continue
+				}
+				gvk := parsedGVK.String()
+				if seenGVKs.Has(gvk) {
+					allErrs = append(allErrs, field.Duplicate(fldPath, f.Name))
+				} else {
+					seenGVKs.Insert(gvk)
+				}
+				if builtInGVKs.Has(gvk) {
+					allErrs = append(allErrs, field.Invalid(fldPath, f.Name, "conflicts with a built-in MultiKueue adapter"))
 				}
 			}
 		}

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/config.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/config.go
@@ -26,14 +26,8 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 )
 
-var (
-	// adapters holds the configured adapters.
-	adapters []*Adapter
-)
-
-// Initialize loads and validates external framework configurations and creates adapters.
-func Initialize(configs []configapi.MultiKueueExternalFramework) error {
-	adapters = nil // Reset on re-initialization
+// NewAdapters creates and returns adapters from the given configurations.
+func NewAdapters(configs []configapi.MultiKueueExternalFramework) ([]*Adapter, error) {
 	configsMap := make(map[schema.GroupVersionKind]configapi.MultiKueueExternalFramework)
 	var errs []error
 
@@ -53,18 +47,14 @@ func Initialize(configs []configapi.MultiKueueExternalFramework) error {
 	}
 
 	if len(errs) > 0 {
-		return k8serrors.NewAggregate(errs)
+		return nil, k8serrors.NewAggregate(errs)
 	}
 
+	var adapters []*Adapter
 	for gvk := range configsMap {
 		adapters = append(adapters, &Adapter{gvk: gvk})
 	}
-	return nil
-}
-
-// GetAllAdapters returns all configured adapters.
-func GetAllAdapters() []*Adapter {
-	return adapters
+	return adapters, nil
 }
 
 // parseGVK parses a string to a GVK

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -117,6 +117,7 @@ MultiKueue supports a wide variety of workloads. You can learn how to:
 - [Dispatch a Kueue managed MPIJob](docs/tasks/run/multikueue/mpijob).
 - [Dispatch a Kueue managed AppWrapper](docs/tasks/run/multikueue/appwrapper).
 - [Dispatch a Kueue managed plain Pod](docs/tasks/run/multikueue/plain_pods).
+- [Dispatch a Kueue managed External Framework Job](docs/tasks/run/multikueue/external-frameworks.md)
 
 ## Submitting Jobs
 

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -117,9 +117,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 				}
 
 				// Get external adapters for MultiKueue synchronization
-				gomega.Expect(externalframeworks.Initialize(cfg.MultiKueue.ExternalFrameworks)).To(gomega.Succeed())
+				externalAdapters, err := externalframeworks.NewAdapters(cfg.MultiKueue.ExternalFrameworks)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				adapters := make(map[string]jobframework.MultiKueueAdapter)
-				for _, adapter := range externalframeworks.GetAllAdapters() {
+				for _, adapter := range externalAdapters {
 					gvk := adapter.GVK()
 					adapters[gvk.String()] = adapter
 				}


### PR DESCRIPTION
Removes global state from adapter creation by replacing the Initialize/GetAllAdapters pattern with a stateless NewAdapters function. This makes the data flow explicit and simplifies testing.

Also removes the unused remoteClient parameter from the syncStatus method.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```